### PR TITLE
Remove tvOS from GitHub Actions

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,8 +18,6 @@ jobs:
         include:
           - platform: 2
             platform_name: ios
-          - platform: 3
-            platform_name: tvos
           - platform: 7
             platform_name: iossimulator
           - platform: 8


### PR DESCRIPTION
These builds do not work outside of the tvOS simulator, UI rewrite is required. For now, disable the builds.